### PR TITLE
Moved link upvote tresholds into a separate config

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1,0 +1,4 @@
+{
+    "link_upvote_threshold": 5,
+    "trending_link_vote_threshold": 50
+}

--- a/src/routes/api/links/+server.ts
+++ b/src/routes/api/links/+server.ts
@@ -1,10 +1,11 @@
 
 import { error } from '@sveltejs/kit';
 import Links from '../../../links';
+import config from '../../../config.json';
 
 export async function GET() {
 
-    const links = (await Links.list()).filter(x => x.votes >= 5)
+    const links = (await Links.list()).filter(x => x.votes >= config.link_upvote_threshold)
 
 	return new Response(
         JSON.stringify(links),

--- a/src/routes/api/newlinks/+server.ts
+++ b/src/routes/api/newlinks/+server.ts
@@ -1,10 +1,11 @@
 
 import { error } from '@sveltejs/kit';
 import Links from '../../../links';
+import config from '../../../config.json';
 
 export async function GET() {
 
-    const links = (await Links.list()).filter(x => x.votes <= 5)
+    const links = (await Links.list()).filter(x => x.votes <= config.link_upvote_threshold)
 
 	return new Response(
         JSON.stringify(links),

--- a/src/routes/api/trendinglinks/+server.ts
+++ b/src/routes/api/trendinglinks/+server.ts
@@ -1,10 +1,13 @@
 
 import { error } from '@sveltejs/kit';
 import Links from '../../../links';
+import config from '../../../config.json';
 
 export async function GET() {
 
-    const links = (await Links.list()).filter(x => x.votes >= 50).sort((a, b) => a.votes - b.votes)
+    const links = (await Links.list())
+        .filter(x => x.votes >= config.trending_link_vote_threshold)
+        .sort((a, b) => a.votes - b.votes)
 
 	return new Response(
         JSON.stringify(links),


### PR DESCRIPTION
Moved link upvote tresholds values that decide which pages the links appear on from the srouce code into a separate JSON config for consistency across all API endpoints - This eliminates the risk of these crucial values differing across source files.