### PR TITLE
/trending links are now sorted by the upvote intensity

### DIFF
--- a/src/links.json
+++ b/src/links.json
@@ -3,35 +3,40 @@
         "link": "https://google.com",
         "title": "Google market share down",
         "description": "Once upon a time at google...",
-        "votes": 34,
-        "id": 0
+        "votes": 59,
+        "id": 0,
+        "timestamp": 168003336437
     },
     {
         "link": "https://google.com",
         "title": "Google loses to bing",
         "description": "Once upon a time at google...",
         "votes": 132,
-        "id": 1
+        "id": 1,
+        "timestamp": 1680012366437
     },
     {
         "link": "https://github.com/4S1ght/soybean",
         "title": "Soybean.",
         "description": "Automation tool, etc...",
-        "votes": 33,
-        "id": 2
+        "votes": 50,
+        "id": 2,
+        "timestamp": 1680033366437
     },
     {
         "link": "https://google.com",
         "title": "A new link",
         "description": "*A creative description*",
         "votes": 3,
-        "id": 3
+        "id": 3,
+        "timestamp": 1680033366437
     },
     {
         "link": "https://google.com",
         "title": "lorem",
         "description": "...ipsum?",
         "votes": 4,
-        "id": 4
+        "id": 4,
+        "timestamp": 1680033366437
     }
 ]

--- a/src/links.ts
+++ b/src/links.ts
@@ -11,6 +11,7 @@ export interface Link {
     description: string
     votes: number
     id: number
+    timestamp: number
 }
 
 export default class Links {

--- a/src/routes/api/trendinglinks/+server.ts
+++ b/src/routes/api/trendinglinks/+server.ts
@@ -1,13 +1,22 @@
 
-import { error } from '@sveltejs/kit';
 import Links from '../../../links';
 import config from '../../../config.json';
 
+import type { Link } from '../../../links';
+
+const day = 24 * 60 * 60 * 1000
+
 export async function GET() {
 
-    const links = (await Links.list())
+    const now = Date.now()
+
+    const links = ((await Links.list()) as Array<Link & { vote_intensity: number }>)
         .filter(x => x.votes >= config.trending_link_vote_threshold)
-        .sort((a, b) => a.votes - b.votes)
+        .map(x => {
+            const age = Math.max(1, Math.round((now - x.timestamp) / day))
+            return { ...x, vote_intensity: x.votes / age }
+        })
+        .sort((a, b) => b.vote_intensity - a.vote_intensity)
 
 	return new Response(
         JSON.stringify(links),


### PR DESCRIPTION
Links on the /tranding page are now sorted by their upvote intensity (number of votes divided by age).
This means the links with most "engagement" rise to the top of the page.